### PR TITLE
part-2 : 포트 변경해서 실행해보기 

### DIFF
--- a/part-2/app.js
+++ b/part-2/app.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express()
+const port = 5050
+
+app.get('/', (req, res) => {
+    res.send('Hello World!')
+})
+
+app.listen(port, () => {
+    console.log(`Example app listening on port ${port}`)
+})

--- a/part-2/package.json
+++ b/part-2/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "part-2",
+  "version": "1.0.0",
+  "description": "part-2",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jungmyungjin/Backend_basic.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/jungmyungjin/Backend_basic/issues"
+  },
+  "homepage": "https://github.com/jungmyungjin/Backend_basic#readme",
+  "dependencies": {
+    "express": "^4.18.1"
+  }
+}


### PR DESCRIPTION
### 왜 80은 포트를 생략해도 되는지  공부해보기

- http의 기본 포트가 80 포트이다.
- 1999년 6월에 나온 [RFC 2616](http://www.rfc-editor.org/rfc/rfc2616.txt) 3.2.2 절을 읽어보면 다음과 같이 `80`포트가 기본 포트로 명시되어 있다.
    
    > If the port is empty or not given, port 80 is assumed.
    만약 포트가 비어 있거나 없으면 포트 80으로 간주한다.
    > 
    
    [참고 링크](https://johngrib.github.io/wiki/why-http-80-https-443/)
    

### 70001이 작동하지 않은 이유 공부해보기

```bash
RangeError [ERR_SOCKET_BAD_PORT]: options.port should be >= 0 and < 65536. Received 70001.
```

포트의 범위를 넘으므로 지원에러가 난다

- port range : **0 to 65535**

### localhost 랑 127.0.0.1이 접근되는 이유 공부해보기

- localhost는 DNS 최상위에 루프백 주소인 127.0.0.1로 매핑이 되어 있기 때문에 같은 루프백 주소로 동일하게 접근이 가능하다.